### PR TITLE
refactor: update deprecated task identifiers in examples

### DIFF
--- a/src/main/java/io/kestra/plugin/cassandra/astradb/Trigger.java
+++ b/src/main/java/io/kestra/plugin/cassandra/astradb/Trigger.java
@@ -37,12 +37,12 @@ import lombok.experimental.SuperBuilder;
 
                 tasks:
                   - id: each
-                    type: io.kestra.core.tasks.flows.ForEach
+                    type: io.kestra.plugin.core.flow.ForEach
                     values: "{{ trigger.rows }}"
                     tasks:
                       - id: return
-                        type: io.kestra.core.tasks.debugs.Return
-                        format: "{{ json(taskrun.value) }}"
+                        type: io.kestra.plugin.core.debug.Return
+                        format: "{{ fromJson(taskrun.value) }}"
 
                 triggers:
                   - id: watch

--- a/src/main/java/io/kestra/plugin/cassandra/standard/Trigger.java
+++ b/src/main/java/io/kestra/plugin/cassandra/standard/Trigger.java
@@ -39,12 +39,12 @@ import lombok.experimental.SuperBuilder;
 
                 tasks:
                   - id: each
-                    type: io.kestra.core.tasks.flows.ForEach
+                    type: io.kestra.plugin.core.flow.ForEach
                     values: "{{ trigger.rows }}"
                     tasks:
                       - id: return
-                        type: io.kestra.core.tasks.debugs.Return
-                        format: "{{ json(taskrun.value) }}"
+                        type: io.kestra.plugin.core.debug.Return
+                        format: "{{ fromJson(taskrun.value) }}"
 
                 triggers:
                   - id: watch

--- a/src/test/resources/flows/cassandra-listen.yml
+++ b/src/test/resources/flows/cassandra-listen.yml
@@ -15,5 +15,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"


### PR DESCRIPTION
Updates the deprecated task identifiers in the examples to their current names