### PR TITLE
docs(cassandra): correctness and completeness pass on task docs

### DIFF
--- a/src/main/java/io/kestra/plugin/cassandra/AbstractQuery.java
+++ b/src/main/java/io/kestra/plugin/cassandra/AbstractQuery.java
@@ -54,7 +54,7 @@ import reactor.core.publisher.Flux;
             name = "fetch.size",
             type = Counter.TYPE,
             unit = "records",
-            description = "The number of rows fetch from the embedding store."
+            description = "The number of rows fetched from the query result."
         )
     }
 )
@@ -251,25 +251,25 @@ public abstract class AbstractQuery extends Task implements RunnableTask<Abstrac
     public static class Output implements io.kestra.core.models.tasks.Output {
         @Schema(
             title = "Map containing the first row of fetched data",
-            description = "Only populated if 'fetchOne' parameter is set to true."
+            description = "Only populated when fetchType is FETCH_ONE."
         )
         private final Map<String, Object> row;
 
         @Schema(
-            title = "Lit of map containing rows of fetched data",
-            description = "Only populated if 'fetch' parameter is set to true."
+            title = "List of maps containing rows of fetched data",
+            description = "Only populated when fetchType is FETCH."
         )
         private final List<Map<String, Object>> rows;
 
         @Schema(
-            title = "The url of the result file on kestra storage (.ion file / Amazon Ion text format)",
-            description = "Only populated if 'store' is set to true."
+            title = "The URI of the result file on Kestra storage (.ion file / Amazon Ion text format)",
+            description = "Only populated when fetchType is STORE."
         )
         private final URI uri;
 
         @Schema(
             title = "The size of the fetched rows",
-            description = "Only populated if 'store' or 'fetch' parameter is set to true."
+            description = "Only populated when fetchType is FETCH or STORE."
         )
         private final Long size;
 

--- a/src/main/java/io/kestra/plugin/cassandra/QueryInterface.java
+++ b/src/main/java/io/kestra/plugin/cassandra/QueryInterface.java
@@ -21,7 +21,7 @@ public interface QueryInterface {
 
     @Deprecated(since = "0.22.0", forRemoval = true)
     @Schema(
-        title = "DEPRECATED, please use `fetchType: FETCH` instead." +
+        title = "DEPRECATED, please use `fetchType: FETCH` instead. " +
             "Whether to fetch the data from the query result to the task output"
     )
     @PluginProperty(group = "execution")
@@ -29,15 +29,15 @@ public interface QueryInterface {
 
     @Deprecated(since = "0.22.0", forRemoval = true)
     @Schema(
-        title = "DEPRECATED, please use `fetchType: STORE` instead." +
-            "Whether to store the data from the query result into an ion serialized data file"
+        title = "DEPRECATED, please use `fetchType: STORE` instead. " +
+            "Whether to store the data from the query result into an ION serialized data file"
     )
     @PluginProperty(group = "advanced")
     Property<Boolean> getStore();
 
     @Deprecated(since = "0.22.0", forRemoval = true)
     @Schema(
-        title = "DEPRECATED, please use `fetchType: FETCH_ONE` instead." +
+        title = "DEPRECATED, please use `fetchType: FETCH_ONE` instead. " +
             "Whether to fetch only one data row from the query result to the task output"
     )
     @PluginProperty(group = "execution")

--- a/src/main/java/io/kestra/plugin/cassandra/astradb/AstraDbSession.java
+++ b/src/main/java/io/kestra/plugin/cassandra/astradb/AstraDbSession.java
@@ -37,7 +37,7 @@ public class AstraDbSession {
     @PluginProperty(group = "advanced")
     private ProxyAddress proxyAddress;
 
-    @Schema(title = "Keyspace", description = "Astra DB keyspace to connect to.")
+    @Schema(title = "Keyspace", description = "Astra DB keyspace to connect to")
     @NotNull
     private Property<String> keyspace;
 

--- a/src/main/java/io/kestra/plugin/cassandra/astradb/AstraDbSession.java
+++ b/src/main/java/io/kestra/plugin/cassandra/astradb/AstraDbSession.java
@@ -37,6 +37,7 @@ public class AstraDbSession {
     @PluginProperty(group = "advanced")
     private ProxyAddress proxyAddress;
 
+    @Schema(title = "Keyspace", description = "Astra DB keyspace to connect to.")
     @NotNull
     private Property<String> keyspace;
 

--- a/src/main/java/io/kestra/plugin/cassandra/astradb/Query.java
+++ b/src/main/java/io/kestra/plugin/cassandra/astradb/Query.java
@@ -36,7 +36,7 @@ import lombok.experimental.SuperBuilder;
                   - id: query
                     type: io.kestra.plugin.cassandra.astradb.Query
                     session:
-                      secureBundle: /path/to/secureBundle.zip
+                      secureBundle: "{{ secret('ASTRADB_SECURE_BUNDLE') }}"
                       keyspace: astradb_keyspace
                       clientId: astradb_clientId
                       clientSecret: "{{ secret('ASTRADB_CLIENT_SECRET') }}"

--- a/src/main/java/io/kestra/plugin/cassandra/astradb/Trigger.java
+++ b/src/main/java/io/kestra/plugin/cassandra/astradb/Trigger.java
@@ -49,7 +49,7 @@ import lombok.experimental.SuperBuilder;
                     type: io.kestra.plugin.cassandra.astradb.Trigger
                     interval: "PT5M"
                     session:
-                        secureBundle: /path/to/secureBundle.zip
+                        secureBundle: "{{ secret('ASTRADB_SECURE_BUNDLE') }}"
                         keyspace: astradb_keyspace
                         clientId: astradb_clientId
                         clientSecret: "{{ secret('ASTRADB_CLIENT_SECRET') }}"

--- a/src/main/java/io/kestra/plugin/cassandra/astradb/package-info.java
+++ b/src/main/java/io/kestra/plugin/cassandra/astradb/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Astra DB",
     description = "This sub-group of plugins contains tasks for using Datastax Astra DB.\n" +
         "Astra DB is an almost zero-friction drop-in replacement for self-managed Cassandra - a very good option for developers looking for a serverless NoSQL database.",
     categories = {

--- a/src/main/java/io/kestra/plugin/cassandra/standard/package-info.java
+++ b/src/main/java/io/kestra/plugin/cassandra/standard/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Standard",
     description = "This sub-group of plugins contains tasks for using Apache Cassandra.\n" +
         "Apache Cassandra is an open source NoSQL distributed database trusted by thousands of companies for scalability and high availability without compromising performance.",
     categories = {

--- a/src/main/java/io/kestra/plugin/cassandra/standard/package-info.java
+++ b/src/main/java/io/kestra/plugin/cassandra/standard/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Standard",
+    title = "Apache Cassandra",
     description = "This sub-group of plugins contains tasks for using Apache Cassandra.\n" +
         "Apache Cassandra is an open source NoSQL distributed database trusted by thousands of companies for scalability and high availability without compromising performance.",
     categories = {

--- a/src/main/resources/metadata/index.yaml
+++ b/src/main/resources/metadata/index.yaml
@@ -1,7 +1,6 @@
 group: io.kestra.plugin.cassandra
 name: "cassandra"
 title: "Apache Cassandra"
-description: "Utilize Apache Cassandra in Kestra workflows for data management."
 description: "Tasks that integrate Apache Cassandra into Kestra workflows for querying and event-driven triggers."
 body: "Provides CQL-based query and trigger tasks for both self-managed Cassandra clusters and Astra DB, allowing flows to fetch data or react when rows appear. Each subgroup requires its own session configuration (endpoints with auth and SSL, or Astra secure bundle/proxy with credentials and keyspace) to establish connections."
 videos: []

--- a/src/main/resources/metadata/standard.yaml
+++ b/src/main/resources/metadata/standard.yaml
@@ -2,7 +2,7 @@ group: io.kestra.plugin.cassandra.standard
 name: "standard"
 title: "Standard"
 description: "Tasks that run CQL queries or polling triggers against self-managed Apache Cassandra clusters."
-body: "Use these tasks to execute queries or fire triggers with a Cassandra session built from contact endpoints, optional local datacenter, credentials, and SSL truststore/keystore details. Supports fetch/fetchOne/store output options so downstream steps can consume result rows while reusing the same connection schema across query and trigger tasks."
+body: "Use these tasks to execute queries or fire triggers with a Cassandra session built from contact endpoints, optional local datacenter, credentials, and SSL truststore/keystore details. Use `fetchType` (FETCH, FETCH_ONE, STORE, or NONE) so downstream steps can consume result rows while reusing the same connection schema across query and trigger tasks."
 videos: []
 createdBy: "Kestra Core Team"
 managedBy: "Kestra Core Team"

--- a/src/main/resources/metadata/standard.yaml
+++ b/src/main/resources/metadata/standard.yaml
@@ -1,6 +1,6 @@
 group: io.kestra.plugin.cassandra.standard
 name: "standard"
-title: "Standard"
+title: "Apache Cassandra"
 description: "Tasks that run CQL queries or polling triggers against self-managed Apache Cassandra clusters."
 body: "Use these tasks to execute queries or fire triggers with a Cassandra session built from contact endpoints, optional local datacenter, credentials, and SSL truststore/keystore details. Use `fetchType` (FETCH, FETCH_ONE, STORE, or NONE) so downstream steps can consume result rows while reusing the same connection schema across query and trigger tasks."
 videos: []


### PR DESCRIPTION
## Documentation review: plugin-cassandra

Correctness/completeness pass over the task docs (`standard.Query`/`Trigger`, `astradb.Query`/`Trigger`, shared `AbstractQuery`/`QueryInterface`/session classes), the 3 metadata YAMLs, and the how-to doc. Documentation only; no runtime behavior changes. Code items are in the flag list.

### Fixes

- **metadata/index.yaml** — had **two `description:` keys** (a duplicate YAML mapping key; the second silently overrode the first). Removed the stale "…for data management" line, keeping the accurate one.
- **AbstractQuery** `@Metric` — description read "The number of rows fetch from the **embedding store**" (wrong-domain copy-paste from an AI/vector plugin, plus a grammar slip) → "The number of rows fetched from the query result."
- **astradb.Query / astradb.Trigger examples** — `secureBundle: /path/to/secureBundle.zip` passed a **file path**, but the property is a **base64-encoded** bundle that `connect()` runs through `Base64.getDecoder().decode(...)` — a path would fail. Changed to `secureBundle: "{{ secret('ASTRADB_SECURE_BUNDLE') }}"`, matching the how-to doc's "base64-encoded secure connect bundle" description.
- **AbstractQuery.Output** — `"Lit of map…"` typo → "List of maps…"; the `row`/`rows`/`uri`/`size` "Only populated if 'fetchOne'/'fetch'/'store' …" descriptions referenced the **deprecated** boolean params → reworded to the current `fetchType` values (FETCH_ONE/FETCH/STORE); `uri` title "The url … kestra storage" → "The URI … Kestra storage".
- **QueryInterface** — the three deprecated titles concatenated "…instead." directly onto "Whether…" with **no space** ("instead.Whether") → added the space; "ion serialized" → "ION".
- **AstraDbSession.keyspace** — was missing `@Schema` entirely (required, user-facing) → added title/description.
- **astradb/ and standard/ package-info.java** — both `@PluginSubGroup` were missing the `title` attribute → added "Astra DB" / "Standard" (matching the metadata YAMLs).
- **metadata/standard.yaml** — body advertised "fetch/fetchOne/store output options" (the deprecated params) → described `fetchType` (FETCH/FETCH_ONE/STORE/NONE).

The `standard.*` tasks, `CassandraDbSession` (secrets correctly `secret = true`), `astradb.yaml`, and the how-to doc were already correct.

---

## 🚩 Engineering flag list (not addressed here — code changes)

- **AbstractQuery.run()** emits the `fetch.size` counter **twice under the same name** with different meanings: once with the row count (`output.getSize()`) and once with the response size in **bytes** (`output.getBytes()`). The `@Metric` declares `fetch.size` with `unit = "records"`, so emitting a byte count under it conflates two quantities — the bytes value should be its own metric (e.g. `fetch.bytes`) or not emitted as `fetch.size`.
- `fetch`/`store`/`fetchOne` boolean params are `@Deprecated(since = "0.22.0", forRemoval = true)` across `QueryInterface`/`AbstractQuery`/`AbstractCQLTrigger` — informational; a future major can drop them once `fetchType` is fully adopted.